### PR TITLE
update color of post details

### DIFF
--- a/src/css/post.css
+++ b/src/css/post.css
@@ -31,7 +31,7 @@ h2 {
 .post__content {
   margin-top: 1rem;
   word-wrap: break-word;
-  /* color: var(--charcoal); */
+  color: var(--white);
 }
 
 .post__content p,


### PR DESCRIPTION
The post details were set to a dark color and due to the background being dark too they weren't visible.

Post details are visible below the title of any post. The details include information such as date and read duration for the post.

#### Example of post details with bad formatting:

<img src="https://user-images.githubusercontent.com/4337699/223974953-8fff6f51-5be8-4147-9e83-518a5cac97f7.png" width="450px" />
